### PR TITLE
Added server port env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # EPlusTV
 
 <p align="center">
@@ -34,6 +35,7 @@ The recommended way of running is to pull the image from [Docker Hub](https://hu
 | ESPN_USER | Your ESPN+ Username | Yes |
 | ESPN_PASS | Your ESPN+ Password | Yes |
 | START_CHANNEL | What the first channel number should be. Keep in mind this generates 100 channels to keep a healthy buffer. | No. If not set, the start channel will default to 1. |
+| PORT | What port the server should expose itself on | No. If not set, the port will default to 8000. |
 
 
 #### Volumes

--- a/index.ts
+++ b/index.ts
@@ -179,8 +179,13 @@ process.on('SIGINT', shutDown);
 
   await schedule();
 
+  let port = 8000;
+  if (process.env.PORT && !isNaN(parseInt(process.env.PORT))){
+  	port = parseInt(process.env.PORT)
+  }
+
   console.log('=== Starting Server ===')
-  app.listen(8000, () => console.log('Server started on port 8000'));
+  app.listen(port, () => console.log(`Server started on port ${port}`));
 })();
 
 


### PR DESCRIPTION
Allows you to specify a custom port on the docker container (it would be the right-hand-side of the port mapping). I needed this because I want to route this container's traffic through [gluetun](https://github.com/qdm12/gluetun/) and port 8000 is already taken.