### PR TITLE
Add <live/> and <new/> on xmltv airings

### DIFF
--- a/services/generate-xmltv.ts
+++ b/services/generate-xmltv.ts
@@ -98,6 +98,18 @@ export const generateXml = async (numChannels: number, startChannel: number) => 
             },
           ],
         },
+        {
+          live: [
+            {},
+            '',
+          ],
+        },
+        {
+          new: [
+            {},
+            '',
+          ],
+        },
         ...formatCategories((entry as any).categories)
       ],
     });


### PR DESCRIPTION
Didn't test this, but I think something like this should work.

See also https://github.com/maddox/pluto-for-channels/blob/main/PlutoIPTV/index.js#L546-L548