### PR TITLE
Add the "Live" category

### DIFF
--- a/services/get-events.ts
+++ b/services/get-events.ts
@@ -4,7 +4,7 @@ import moment from 'moment';
 import { db } from './database';
 
 const parseCategories = event => {
-  const categories = ['Sports'];
+  const categories = ['Sports', 'Live'];
   for (const classifier of [event.category, event.subcategory, event.sport, event.league]){
     if (classifier !== null && classifier.name !== null){
       categories.push(classifier.name);


### PR DESCRIPTION
This adds the "Live" category to all entries. 

All categories in xmltv data are applied to Airings in Channels as tags. Tags are used extensively by Channels with Smart Rules and other presentation. 

This gets the ESPlus airings working a little better inside Channels.