### PR TITLE
Allow express server port to be set from environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN \
   cd /app && \
   npm ci
 
-EXPOSE ${PORT}
+EXPOSE ${PORT:-8080}
 
 RUN chmod +x entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,6 @@ RUN \
   cd /app && \
   npm ci
 
-EXPOSE ${PORT:-8080}
-
 RUN chmod +x entrypoint.sh
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN \
   cd /app && \
   npm ci
 
-EXPOSE 8000
+EXPOSE ${PORT}
 
 RUN chmod +x entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ The recommended way of running is to pull the image from [Docker Hub](https://hu
 | PROXY_SEGMENTS | Proxy keyed `*.ts` files. | No | False |
 | PUID | Current user ID. Use if you have permission issues. Needs to be combined with PGID. | No ||
 | PGID | Current group ID. Use if you have permission issues. Needs to be combined with PUID. | No ||
-| MAX_RESOLUTION | Max resolution to use. Valid options are `UHD/HDR`, `UHD/SDR`, `1080p`, `720p`, and `540p` (Some providers don't offer 4K or 1080p and will attempt to play the highest framerate available for selected resolution). | No | UHD/SDR |
+| MAX_RESOLUTION | Max resolution to use. Valid options are `UHD/HDR`, `UHD/SDR`, `1080p`, `720p`, and `540p` (Some providers don't offer 4K or 1080p and will attempt to play the highest framerate available for selected resolution). | No | UHD/SDR ||
+| PORT | Port the API will be served on. You can set this if it conflicts with another service in your environment. | No | 8000 |
 
 ### Available channel options
 

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,7 @@ import {foxHandler} from './services/fox-handler';
 import {mlbHandler} from './services/mlb-handler';
 import {cleanEntries, removeChannelStatus} from './services/shared-helpers';
 import {appStatus} from './services/app-status';
+import {SERVER_PORT} from './services/port';
 
 import {version} from './package.json';
 
@@ -199,7 +200,7 @@ process.on('SIGINT', shutDown);
   await schedule();
 
   console.log('=== Starting Server ===');
-  app.listen(8000, () => console.log('Server started on port 8000'));
+  app.listen(SERVER_PORT, () => console.log(`Server started on port ${SERVER_PORT}`));
 })();
 
 // Check for events every 4 hours and set the schedule

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "eplustv",
-      "version": "2.0.16",
+      "version": "2.0.17",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.2.2",

--- a/services/port.ts
+++ b/services/port.ts
@@ -1,0 +1,8 @@
+import _ from 'lodash';
+
+let serverPort = _.toNumber(process.env.PORT);
+if (_.isNaN(serverPort)) {
+  serverPort = 8000;
+}
+
+export const SERVER_PORT = serverPort;


### PR DESCRIPTION
After failing to run this container using another container as it's network (for purposes of utilizing a VPN), and finding multiple old issues about people requesting a configurable port for this, I decided to do the work to make the port configurable via an environment variable on the docker container. 

My use case was that gluetun VPN uses port 8000 in it's container, so running EPlusTV through that VPN would not work, since ::8000 was already in use. 

In this implementation, if the user does not specify a `PORT` environment variable, this container will work the same as it always did, using port 8000. However, if a user does specify the `PORT` variable, the express server will run on whatever port is specified.