### PR TITLE
optional xmltv improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ The recommended way of running is to pull the image from [Docker Hub](https://hu
 | PUID | Current user ID. Use if you have permission issues. Needs to be combined with PGID. | No | - |
 | PGID | Current group ID. Use if you have permission issues. Needs to be combined with PUID. | No | - |
 | PORT | Port the API will be served on. You can set this if it conflicts with another service in your environment. | No | 8000 |
-| XMLTV_PADDING | Show extra event padding in generated XMLTV schedule | No | True |
 
 ### Available Providers
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The recommended way of running is to pull the image from [Docker Hub](https://hu
 | PUID | Current user ID. Use if you have permission issues. Needs to be combined with PGID. | No | - |
 | PGID | Current group ID. Use if you have permission issues. Needs to be combined with PUID. | No | - |
 | PORT | Port the API will be served on. You can set this if it conflicts with another service in your environment. | No | 8000 |
+| XMLTV_PADDING | Show extra event padding in generated XMLTV schedule | No | True |
 
 ### Available Providers
 

--- a/index.tsx
+++ b/index.tsx
@@ -52,7 +52,7 @@ import {NFL} from './services/providers/nfl/views';
 import {ESPN} from './services/providers/espn/views';
 import {ESPNPlus} from './services/providers/espn-plus/views';
 import {Gotham} from './services/providers/gotham/views';
-import { initMiscDb, resetLinearStartChannel, setLinear, setNumberofChannels, setProxySegments, setStartChannel, usesLinear } from './services/misc-db-service';
+import { initMiscDb, resetLinearStartChannel, setLinear, setNumberofChannels, setProxySegments, setStartChannel, usesLinear, setXmltvPadding } from './services/misc-db-service';
 
 // Set timeout of requests to 1 minute
 axios.defaults.timeout = 1000 * 60;
@@ -252,6 +252,33 @@ app.post('/proxy-segments', async c => {
       'HX-Trigger': `{"HXToast":{"type":"success","body":"Successfully ${
         enabled ? 'enabled' : 'disabled'
       } proxying of segment files"}}`,
+    },
+  );
+});
+
+app.post('/xmltv-padding', async c => {
+  const body = await c.req.parseBody();
+  const enabled = body['xmltv-padding'] === 'on';
+
+  await setXmltvPadding(enabled);
+
+  return c.html(
+    <input
+      hx-post="/xmltv-padding"
+      hx-target="this"
+      hx-swap="outerHTML"
+      hx-trigger="change"
+      name="xmltv-padding"
+      type="checkbox"
+      role="switch"
+      checked={enabled}
+      data-enabled={enabled ? 'true' : 'false'}
+    />,
+    200,
+    {
+      'HX-Trigger': `{"HXToast":{"type":"success","body":"Successfully ${
+        enabled ? 'enabled' : 'disabled'
+      } XMLTV padding"}}`,
     },
   );
 });

--- a/services/b1g-handler.ts
+++ b/services/b1g-handler.ts
@@ -121,6 +121,7 @@ const parseAirings = async (events: IB1GEvent[]) => {
       if (!entryExists) {
         const start = moment(event.startTime);
         const end = moment(event.startTime).add(4, 'hours');
+        const xmltvEnd = moment(event.startTime).add(3, 'hours');
 
         if (end.isBefore(now) || start.isAfter(endDate) || content.enableDrmProtection) {
           continue;
@@ -139,6 +140,7 @@ const parseAirings = async (events: IB1GEvent[]) => {
           network: 'B1G+',
           sport: gameData.sport,
           start: start.valueOf(),
+          xmltvEnd: xmltvEnd.valueOf(),
         });
       }
     }

--- a/services/channels.ts
+++ b/services/channels.ts
@@ -301,3 +301,5 @@ export const calculateChannelFromName = (channelName: string): number => {
 
   return channelNum;
 };
+
+export const XMLTV_PADDING = process.env.XMLTV_PADDING?.toLowerCase() === 'false' ? false : true;

--- a/services/espn-handler.ts
+++ b/services/espn-handler.ts
@@ -347,6 +347,7 @@ const parseAirings = async events => {
 
       const start = moment(event.startDateTime);
       const end = moment(event.startDateTime).add(event.duration, 'seconds').add(1, 'hour');
+      const xmltvEnd = moment(event.startDateTime).add(event.duration, 'seconds');
 
       if (!isLinear) {
         end.add(1, 'hour');
@@ -375,6 +376,7 @@ const parseAirings = async events => {
           channel: event.network?.id,
           linear: true,
         }),
+        xmltvEnd: xmltvEnd.valueOf(),
       });
     }
   }

--- a/services/flo-handler.ts
+++ b/services/flo-handler.ts
@@ -58,6 +58,7 @@ const parseAirings = async (events: IFloEvent[]) => {
       if (!entryExists) {
         const start = moment(event.label_1_parts.start_date_time);
         const end = moment(event.label_1_parts.start_date_time).add(4, 'hours');
+        const xmltvEnd = moment(event.label_1_parts.start_date_time).add(3, 'hours');
 
         if (end.isBefore(now) || start.isAfter(endSchedule)) {
           continue;
@@ -78,6 +79,7 @@ const parseAirings = async (events: IFloEvent[]) => {
           network: event.action.analytics.site_name,
           sport: event.footer_1,
           start: start.valueOf(),
+          xmltvEnd: xmltvEnd.valueOf(),
         });
       }
     }

--- a/services/fox-handler.ts
+++ b/services/fox-handler.ts
@@ -133,6 +133,7 @@ const parseAirings = async (events: IFoxEvent[]) => {
     if (!entryExists) {
       const start = moment(event.startDate);
       const end = moment(event.endDate);
+      const xmltvEnd = moment(event.endDate);
       const isLinear = event.network !== 'fox' && useLinear;
 
       if (!isLinear) {
@@ -168,6 +169,7 @@ const parseAirings = async (events: IFoxEvent[]) => {
           channel: event.network,
           linear: true,
         }),
+        xmltvEnd: xmltvEnd.valueOf(),
       });
     }
   }

--- a/services/generate-xmltv.ts
+++ b/services/generate-xmltv.ts
@@ -3,7 +3,7 @@ import xml from 'xml';
 import moment from 'moment';
 
 import {db} from './database';
-import {calculateChannelFromName, CHANNELS, LINEAR_START_CHANNEL, NUM_OF_CHANNELS, START_CHANNEL} from './channels';
+import {calculateChannelFromName, CHANNELS, LINEAR_START_CHANNEL, NUM_OF_CHANNELS, START_CHANNEL, XMLTV_PADDING} from './channels';
 import {IEntry} from './shared-interfaces';
 
 const baseCategories = ['HD', 'HDTV', 'Sports event', 'Sports'];
@@ -146,13 +146,15 @@ export const generateXml = async (linear = false): Promise<xml> => {
 
     const entryName = formatEntryName(entry, useMultiple);
 
+    const end = (XMLTV_PADDING || !entry.xmltvEnd) ? entry.end : entry.xmltvEnd;
+
     wrap.tv.push({
       programme: [
         {
           _attr: {
             channel: `${channelNum}.eplustv`,
             start: moment(entry.start).format('YYYYMMDDHHmmss ZZ'),
-            stop: moment(entry.end).format('YYYYMMDDHHmmss ZZ'),
+            stop: moment(end).format('YYYYMMDDHHmmss ZZ'),
           },
         },
         {

--- a/services/generate-xmltv.ts
+++ b/services/generate-xmltv.ts
@@ -9,13 +9,13 @@ import {getLinearStartChannel, getNumberOfChannels, getStartChannel, xmltvPaddin
 
 const baseCategories = ['HD', 'HDTV', 'Sports event', 'Sports'];
 
-const usesMultiple = async (): Promise<boolean> => {
+export const usesMultiple = async (): Promise<boolean> => {
   const enabledProviders = await db.providers.count({enabled: true});
 
   return enabledProviders > 1;
 };
 
-const formatEntryName = (entry: IEntry, usesMultiple: boolean) => {
+export const formatEntryName = (entry: IEntry, usesMultiple: boolean) => {
   let entryName = entry.name;
 
   if (entry.feed) {

--- a/services/generate-xmltv.ts
+++ b/services/generate-xmltv.ts
@@ -5,7 +5,7 @@ import moment from 'moment';
 import {db} from './database';
 import {calculateChannelFromName, CHANNELS} from './channels';
 import {IEntry} from './shared-interfaces';
-import {getLinearStartChannel, getNumberOfChannels, getStartChannel} from './misc-db-service';
+import {getLinearStartChannel, getNumberOfChannels, getStartChannel, xmltvPadding} from './misc-db-service';
 
 const baseCategories = ['HD', 'HDTV', 'Sports event', 'Sports'];
 
@@ -49,6 +49,7 @@ export const generateXml = async (linear = false): Promise<xml> => {
   const startChannel = await getStartChannel();
   const numOfChannels = await getNumberOfChannels();
   const linearStartChannel = await getLinearStartChannel();
+  const xmltvPadded = await xmltvPadding();
 
   const wrap: any = {
     tv: [
@@ -149,7 +150,7 @@ export const generateXml = async (linear = false): Promise<xml> => {
 
     const entryName = formatEntryName(entry, useMultiple);
 
-    const end = (XMLTV_PADDING || !entry.xmltvEnd) ? entry.end : entry.xmltvEnd;
+    const end = (xmltvPadded || !entry.xmltvEnd) ? entry.end : entry.xmltvEnd;
 
     wrap.tv.push({
       programme: [

--- a/services/misc-db-service.ts
+++ b/services/misc-db-service.ts
@@ -85,6 +85,15 @@ export const initMiscDb = async (): Promise<void> => {
     });
   }
 
+  const setupXmltvPadding = (await db.misc.count({name: 'xmltv_padding'})) > 0 ? true : false;
+
+  if (!setupXmltvPadding) {
+    await db.misc.insert<IMiscDbEntry<boolean>>({
+      name: 'xmltv_padding',
+      value: true,
+    });
+  }
+
   if (linearChannelsEnv) {
     console.log('Using LINEAR_CHANNELS variable is no longer needed. Please use the UI going forward');
   }
@@ -156,3 +165,12 @@ export const proxySegments = async (): Promise<boolean> => {
 
 export const setProxySegments = async (value: boolean): Promise<number> =>
   db.misc.update({name: 'proxy_segments'}, {$set: {value}});
+
+export const xmltvPadding = async (): Promise<boolean> => {
+  const {value} = await db.misc.findOne<IMiscDbEntry<boolean>>({name: 'xmltv_padding'});
+
+  return value;
+};
+
+export const setXmltvPadding = async (value: boolean): Promise<number> =>
+  db.misc.update({name: 'xmltv_padding'}, {$set: {value}});

--- a/services/mlb-handler.ts
+++ b/services/mlb-handler.ts
@@ -152,6 +152,7 @@ const parseAirings = async (events: ICombinedGame) => {
 
           const start = moment(event.gameDate);
           const end = moment(event.gameDate).add(5, 'hours');
+          const xmltvEnd = moment(event.gameDate).add(3, 'hours');
 
           if (end.isBefore(now) || start.isAfter(endDate)) {
             continue;
@@ -172,6 +173,7 @@ const parseAirings = async (events: ICombinedGame) => {
             network: epg.callLetters,
             sport: 'MLB',
             start: start.valueOf(),
+            xmltvEnd: xmltvEnd.valueOf(),
           });
         }
       }

--- a/services/mw-handler.ts
+++ b/services/mw-handler.ts
@@ -34,6 +34,7 @@ const parseAirings = async (events: IMWEvent[]) => {
     if (!entryExists) {
       const start = moment(event.start_time);
       const end = moment(event.end_time).add(1, 'hours');
+      const xmltvEnd = moment(event.end_time);
 
       if (end.isBefore(now) || event.format !== 'video' || start.isAfter(endSchedule)) {
         continue;
@@ -53,6 +54,7 @@ const parseAirings = async (events: IMWEvent[]) => {
         sport: event.sport_category_title,
         start: start.valueOf(),
         url: event.value,
+        xmltvEnd: xmltvEnd.valueOf(),
       });
     }
   }

--- a/services/nfl-handler.ts
+++ b/services/nfl-handler.ts
@@ -179,6 +179,7 @@ const parseAirings = async (events: INFLEvent[]) => {
     if (!entryExists) {
       const start = moment(event.startTime);
       const end = moment(start).add(event.duration, 'seconds');
+      const xmltvEnd = moment(start).add(event.duration, 'seconds');
 
       const isLinear =
         useLinear &&
@@ -219,6 +220,7 @@ const parseAirings = async (events: INFLEvent[]) => {
           linear: true,
           replay: event.callSign === 'NFLDIGITAL1_OO_v3' || event.broadcastAiringType === 'REAIR',
         }),
+        xmltvEnd: xmltvEnd.valueOf(),
       });
     }
   }

--- a/services/paramount-handler.ts
+++ b/services/paramount-handler.ts
@@ -141,6 +141,7 @@ const parseAirings = async (events: IParamountEvent[]) => {
     if (!entryExists) {
       const start = moment(event.startTimestamp);
       const end = moment(event.endTimestamp);
+      const xmltvEnd = moment(event.endTimestamp);
 
       if (!event.linear) {
         end.add(1, 'hour');
@@ -172,6 +173,7 @@ const parseAirings = async (events: IParamountEvent[]) => {
           : {
               sport: event.channelName,
             }),
+        xmltvEnd: xmltvEnd.valueOf(),
       });
     }
   }

--- a/services/providers/espn-plus/index.tsx
+++ b/services/providers/espn-plus/index.tsx
@@ -39,7 +39,7 @@ espnplus.put('/toggle-ppv', async c => {
 
   const {enabled, tokens} = await db.providers.update<IProvider<TESPNPlusTokens, IEspnPlusMeta>>(
     {name: 'espnplus'},
-    {$set: {meta: {use_ppv}}},
+    {$set: {'meta.use_ppv': use_ppv}},
     {returnUpdatedDocs: true},
   );
 
@@ -54,7 +54,7 @@ espnplus.post('/category-filter', async c => {
 
   await db.providers.update(
     {name: 'espnplus'},
-    {$set: {meta: {category_filter}}}
+    {$set: {'meta.category_filter': category_filter}}
   );
 
   await removeEvents();
@@ -76,8 +76,8 @@ espnplus.post('/category-filter', async c => {
         <input
           type="text"
           placeholder="comma-separated list of categories to include, leave blank for all"
-          value={category_filter}
-          data-value={category_filter}
+          value={category_filter.toString()}
+          data-value={category_filter.toString()}
           name="espnplus-category-filter"
         />
         <button type="submit" id="category-filter-button">
@@ -86,6 +86,47 @@ espnplus.post('/category-filter', async c => {
       </fieldset>
     </label>, 200, {
     'HX-Trigger': `{"HXToast":{"type":"success","body":"Successfully saved category filter"}}`,
+  });
+});
+
+espnplus.post('/title-filter', async c => {
+  const body = await c.req.parseBody();
+  const title_filter = body['espnplus-title-filter'];
+
+  await db.providers.update(
+    {name: 'espnplus'},
+    {$set: {'meta.title_filter': title_filter}}
+  );
+
+  await removeEvents();
+  await scheduleEvents();
+
+  return c.html(
+    <label>
+      <span>
+        Title Filter{' '}
+        <span
+          class="warning-red"
+          data-tooltip="Making changes will break/invalidate existing ESPN+ scheduled recordings"
+          data-placement="right"
+        >
+          **
+        </span>
+      </span>
+      <fieldset role="group">
+        <input
+          type="text"
+          placeholder="if specified, only include events with matching titles; supports regular expressions"
+          value={title_filter.toString()}
+          data-value={title_filter.toString()}
+          name="espnplus-title-filter"
+        />
+        <button type="submit" id="title-filter-button">
+          Save
+        </button>
+      </fieldset>
+    </label>, 200, {
+    'HX-Trigger': `{"HXToast":{"type":"success","body":"Successfully saved title filter"}}`,
   });
 });
 

--- a/services/providers/espn-plus/index.tsx
+++ b/services/providers/espn-plus/index.tsx
@@ -48,6 +48,47 @@ espnplus.put('/toggle-ppv', async c => {
   return c.html(<ESPNPlusBody enabled={enabled} tokens={tokens} />);
 });
 
+espnplus.post('/category-filter', async c => {
+  const body = await c.req.parseBody();
+  const category_filter = body['espnplus-category-filter'];
+
+  await db.providers.update(
+    {name: 'espnplus'},
+    {$set: {meta: {category_filter}}}
+  );
+
+  await removeEvents();
+  await scheduleEvents();
+
+  return c.html(
+    <label>
+      <span>
+        Category Filter (<a href="https://www.espn.com/espnplus/browse/" target="_blank">examples</a>){' '}
+        <span
+          class="warning-red"
+          data-tooltip="Making changes will break/invalidate existing ESPN+ scheduled recordings"
+          data-placement="right"
+        >
+          **
+        </span>
+      </span>
+      <fieldset role="group">
+        <input
+          type="text"
+          placeholder="comma-separated list of categories to include, leave blank for all"
+          value={category_filter}
+          data-value={category_filter}
+          name="espnplus-category-filter"
+        />
+        <button type="submit" id="category-filter-button">
+          Save
+        </button>
+      </fieldset>
+    </label>, 200, {
+    'HX-Trigger': `{"HXToast":{"type":"success","body":"Successfully saved category filter"}}`,
+  });
+});
+
 espnplus.get('/login/check/:code', async c => {
   const code = c.req.param('code');
 

--- a/services/providers/espn-plus/index.tsx
+++ b/services/providers/espn-plus/index.tsx
@@ -64,35 +64,9 @@ espnplus.put('/save-filters', async c => {
   await scheduleEvents();
 
   return c.html(
-    <div>
-      <span>
-        Category Filter
-      </span>
-      <fieldset role="group">
-        <input
-          type="text"
-          placeholder="comma-separated list of categories to include, leave blank for all"
-          value={category_filter}
-          data-value={category_filter}
-          name="espnplus-category-filter"
-        />
-      </fieldset>
-      <span>
-        Title Filter
-      </span>
-      <fieldset role="group">
-        <input
-          type="text"
-          placeholder="if specified, only include events with matching titles; supports regular expressions"
-          value={title_filter}
-          data-value={title_filter}
-          name="espnplus-title-filter"
-        />
-      </fieldset>
-      <button type="submit" id="espnplus-save-filters-button">
-        Save and Apply Filters
-      </button>
-    </div>, 200, {
+    <button type="submit" id="espnplus-save-filters-button">
+      Save and Apply Filters
+    </button>, 200, {
     'HX-Trigger': `{"HXToast":{"type":"success","body":"Successfully saved and applied filters"}}`,
   });
 });

--- a/services/providers/espn-plus/views/index.tsx
+++ b/services/providers/espn-plus/views/index.tsx
@@ -50,11 +50,53 @@ export const ESPNPlus: FC = async () => {
             </label>
           </fieldset>
         </div>
+        <div class="grid">
+          <form id="category-filter" hx-post="/providers/espnplus/category-filter" hx-trigger="submit">
+            <label>
+              <span>
+                Category Filter (<a href="https://www.espn.com/espnplus/browse/" target="_blank">examples</a>){' '}
+                <span
+                  class="warning-red"
+                  data-tooltip="Making changes will break/invalidate existing ESPN+ scheduled recordings"
+                  data-placement="right"
+                >
+                  **
+                </span>
+              </span>
+              <fieldset role="group">
+                <input
+                  type="text"
+                  placeholder="comma-separated list of categories to include, leave blank for all"
+                  value={meta.category_filter}
+                  data-value={meta.category_filter}
+                  name="espnplus-category-filter"
+                />
+                <button type="submit" id="category-filter-button">
+                  Save
+                </button>
+              </fieldset>
+            </label>
+          </form>
+        </div>
         <div id="espnplus-body" hx-swap="innerHTML">
           <ESPNPlusBody enabled={enabled} tokens={tokens} />
         </div>
       </section>
       <hr />
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `
+          var rebuildEpgForm = document.getElementById('category-filter');
+
+          if (rebuildEpgForm) {
+            rebuildEpgForm.addEventListener('htmx:beforeRequest', function() {
+              this.querySelector('#category-filter-button').setAttribute('aria-busy', 'true');
+              this.querySelector('#category-filter-button').setAttribute('aria-label', 'Loading…');
+            });
+          }
+        `,
+        }}
+      />
     </div>
   );
 };

--- a/services/providers/espn-plus/views/index.tsx
+++ b/services/providers/espn-plus/views/index.tsx
@@ -50,81 +50,89 @@ export const ESPNPlus: FC = async () => {
             </label>
           </fieldset>
         </div>
-        <div class="grid">
-          <form id="category-filter" hx-post="/providers/espnplus/category-filter" hx-trigger="submit">
-            <label>
-              <span>
-                Category Filter (<a href="https://www.espn.com/espnplus/browse/" target="_blank">examples</a>){' '}
-                <span
-                  class="warning-red"
-                  data-tooltip="Making changes will break/invalidate existing ESPN+ scheduled recordings"
-                  data-placement="right"
-                >
-                  **
-                </span>
-              </span>
-              <fieldset role="group">
-                <input
-                  type="text"
-                  placeholder="comma-separated list of categories to include, leave blank for all"
-                  value={meta.category_filter}
-                  data-value={meta.category_filter}
-                  name="espnplus-category-filter"
-                />
-                <button type="submit" id="category-filter-button">
-                  Save
-                </button>
-              </fieldset>
-            </label>
-          </form>
-        </div>
-        <div class="grid">
-          <form id="title-filter" hx-post="/providers/espnplus/title-filter" hx-trigger="submit">
-            <label>
-              <span>
-                Title Filter{' '}
-                <span
-                  class="warning-red"
-                  data-tooltip="Making changes will break/invalidate existing ESPN+ scheduled recordings"
-                  data-placement="right"
-                >
-                  **
-                </span>
-              </span>
-              <fieldset role="group">
-                <input
-                  type="text"
-                  placeholder="if specified, only include events with matching titles; supports regular expressions"
-                  value={meta.title_filter}
-                  data-value={meta.title_filter}
-                  name="espnplus-title-filter"
-                />
-                <button type="submit" id="title-filter-button">
-                  Save
-                </button>
-              </fieldset>
-            </label>
-          </form>
-        </div>
         <div id="espnplus-body" hx-swap="innerHTML">
           <ESPNPlusBody enabled={enabled} tokens={tokens} />
         </div>
+        <div class="grid">
+          <details>
+            <summary>ESPN+ Options{' '}
+              <span
+                class="warning-red"
+                data-tooltip="Making changes will break/invalidate existing ESPN+ scheduled recordings"
+                data-placement="right"
+              >
+                **
+              </span>
+            </summary>
+            <span>
+              In-Market Teams
+            </span>
+            <fieldset role="group">
+              <form id="espnplus-refresh-in-market-teams" hx-put="/providers/espnplus/refresh-in-market-teams" hx-trigger="submit">
+                <div>
+                  <pre>{meta.in_market_teams} ({meta.zip_code})</pre>
+                  <button id="espnplus-refresh-in-market-teams-button">Refresh In-Market Teams</button>
+                </div>
+              </form>
+            </fieldset>
+            <form id="espnplus-event-filters" hx-put="/providers/espnplus/save-filters" hx-trigger="submit">
+              <div>
+                <span>
+                  Category Filter
+                </span>
+                <fieldset role="group">
+                  <input
+                    type="text"
+                    placeholder="comma-separated list of categories to include, leave blank for all"
+                    value={meta.category_filter}
+                    data-value={meta.category_filter}
+                    name="espnplus-category-filter"
+                  />
+                </fieldset>
+                <span>
+                  Title Filter
+                </span>
+                <fieldset role="group">
+                  <input
+                    type="text"
+                    placeholder="if specified, only include events with matching titles; supports regular expressions"
+                    value={meta.title_filter}
+                    data-value={meta.title_filter}
+                    name="espnplus-title-filter"
+                  />
+                </fieldset>
+                <button type="submit" id="espnplus-save-filters-button">
+                  Save and Apply Filters
+                </button>
+              </div>
+            </form>
+          </details>
+        </div>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+            var rebuildEpgForm = document.getElementById('espnplus-event-filters');
+
+            if (rebuildEpgForm) {
+              rebuildEpgForm.addEventListener('htmx:beforeRequest', function() {
+                this.querySelector('#espnplus-save-filters-button').setAttribute('aria-busy', 'true');
+                this.querySelector('#espnplus-save-filters-button').setAttribute('aria-label', 'Loading…');
+              });
+            }
+
+            var rebuildEpgForm = document.getElementById('espnplus-refresh-in-market-teams');
+
+            if (rebuildEpgForm) {
+              rebuildEpgForm.addEventListener('htmx:beforeRequest', function() {
+                this.querySelector('#espnplus-refresh-in-market-teams-button').setAttribute('aria-busy', 'true');
+                this.querySelector('#espnplus-refresh-in-market-teams-button').setAttribute('aria-label', 'Loading…');
+              });
+            }
+          `,
+          }}
+        />
       </section>
       <hr />
-      <script
-        dangerouslySetInnerHTML={{
-          __html: `
-          var rebuildEpgForm = document.getElementById('category-filter');
-
-          if (rebuildEpgForm) {
-            rebuildEpgForm.addEventListener('htmx:beforeRequest', function() {
-              this.querySelector('#category-filter-button').setAttribute('aria-busy', 'true');
-              this.querySelector('#category-filter-button').setAttribute('aria-label', 'Loading…');
-            });
-          }
-        `,
-        }}
-      />
     </div>
   );
 };

--- a/services/providers/espn-plus/views/index.tsx
+++ b/services/providers/espn-plus/views/index.tsx
@@ -75,7 +75,7 @@ export const ESPNPlus: FC = async () => {
                 </div>
               </form>
             </fieldset>
-            <form id="espnplus-event-filters" hx-put="/providers/espnplus/save-filters" hx-trigger="submit">
+            <form id="espnplus-event-filters" hx-put="/providers/espnplus/save-filters" hx-trigger="submit" hx-swap="outerHTML" hx-target="#espnplus-save-filters-button">
               <div>
                 <span>
                   Category Filter

--- a/services/providers/espn-plus/views/index.tsx
+++ b/services/providers/espn-plus/views/index.tsx
@@ -78,6 +78,34 @@ export const ESPNPlus: FC = async () => {
             </label>
           </form>
         </div>
+        <div class="grid">
+          <form id="title-filter" hx-post="/providers/espnplus/title-filter" hx-trigger="submit">
+            <label>
+              <span>
+                Title Filter{' '}
+                <span
+                  class="warning-red"
+                  data-tooltip="Making changes will break/invalidate existing ESPN+ scheduled recordings"
+                  data-placement="right"
+                >
+                  **
+                </span>
+              </span>
+              <fieldset role="group">
+                <input
+                  type="text"
+                  placeholder="if specified, only include events with matching titles; supports regular expressions"
+                  value={meta.title_filter}
+                  data-value={meta.title_filter}
+                  name="espnplus-title-filter"
+                />
+                <button type="submit" id="title-filter-button">
+                  Save
+                </button>
+              </fieldset>
+            </label>
+          </form>
+        </div>
         <div id="espnplus-body" hx-swap="innerHTML">
           <ESPNPlusBody enabled={enabled} tokens={tokens} />
         </div>

--- a/services/shared-interfaces.ts
+++ b/services/shared-interfaces.ts
@@ -49,6 +49,7 @@ export interface IEntry {
   sport?: string;
   linear?: boolean;
   replay?: boolean;
+  xmltvEnd?: number;
 }
 
 export interface IChannel {

--- a/views/Options.tsx
+++ b/views/Options.tsx
@@ -1,12 +1,13 @@
 import type {FC} from 'hono/jsx';
 
-import { getNumberOfChannels, getStartChannel, proxySegments, usesLinear } from '@/services/misc-db-service';
+import { getNumberOfChannels, getStartChannel, proxySegments, usesLinear, xmltvPadding } from '@/services/misc-db-service';
 
 export const Options: FC = async () => {
   const startChannel = await getStartChannel();
   const numOfChannels = await getNumberOfChannels();
   const linearChannels = await usesLinear();
   const proxiedSegments = await proxySegments();
+  const xmltvPadded = await xmltvPadding();
 
   return (
     <section hx-swap="outerHTML" hx-target="this">
@@ -112,6 +113,22 @@ export const Options: FC = async () => {
               data-enabled={proxiedSegments ? 'true' : 'false'}
             />
             Proxy segment files?
+          </label>
+        </fieldset>
+        <fieldset>
+          <label>
+            <input
+              hx-post="/xmltv-padding"
+              hx-target="this"
+              hx-swap="outerHTML"
+              hx-trigger="change"
+              name="xmltv-padding"
+              type="checkbox"
+              role="switch"
+              checked={xmltvPadded}
+              data-enabled={xmltvPadded ? 'true' : 'false'}
+            />
+            Pad XMLTV event end times?
           </label>
         </fieldset>
       </div>


### PR DESCRIPTION
This pull request adds four new options/features to improve the XMLTV guide data.

1. automatic detection of in-market events, to omit them (E+ only)
2. a "Category filter" text box for an optional comma-separated list of category events to include (E+ only)
3. a "Title filter" text box for an optional filter for matching event names (E+ only, supports regex)
4. a "Pad XMLTV event end times?" UI toggle (defaults to true, to maintain the current behavior) (applies to all providers)

The latter toggle works in conjunction with a new optional "xmltvEnd" field in the entries database, which stores the unpadded event end time (if known). When the "Pad XMLTV?" toggle is disable, the generated XML will use that unpadded value if present. This prevents the guide from displaying excessively long game blocks, while internally, the streams themselves still use the padded time (allowing them to be tuned past their XMLTV end time, if necessary).