### PR TITLE
Fix Fox Soccer Plus and Bally Linear Channels

### DIFF
--- a/services/bally-handler.ts
+++ b/services/bally-handler.ts
@@ -332,7 +332,7 @@ class BallyHandler {
         const channelData = data.channels.find(c => c.uuid === channelId);
 
         if (channelData) {
-          return [channelData.stream_info.apple_tv.default_abr, {}];
+          return [channelData.stream_info.connected_tv.default_abr, {}];
         } else {
           throw new Error('Could not start playback');
         }

--- a/services/channels.ts
+++ b/services/channels.ts
@@ -95,8 +95,8 @@ export const CHANNELS = {
         tvgName: 'BIG10HD',
       },
       13: {
-        checkChannelEnabled: () => checkChannelEnabled('foxsports', 'fsp'),
-        id: 'fsp',
+        checkChannelEnabled: () => checkChannelEnabled('foxsports', 'fox-soccer-plus'),
+        id: 'fox-soccer-plus',
         logo: 'https://tmsimg.fancybits.co/assets/s66880_ll_h15_aa.png?w=360&h=270',
         name: 'FOX Soccer Plus',
         stationId: '66880',

--- a/services/fox-handler.ts
+++ b/services/fox-handler.ts
@@ -117,7 +117,7 @@ const EPG_API_KEY = [
   '3',
 ].join('');
 
-const network_entitlement_map = { fox: 'foxSports', btn: 'btn-btn2go', fsp: 'fspl' };
+const network_entitlement_map = { fox: 'foxSports', btn: 'btn-btn2go', 'fox-soccer-plus': 'fspl' };
 
 const foxConfigPath = path.join(configPath, 'fox_tokens.json');
 
@@ -304,7 +304,7 @@ class FoxHandler {
     if ( linear_channels.length <= 4 ) {
       linear_channels[3] = {
     	enabled: true,
-        id: 'fsp',
+        id: 'fox-soccer-plus',
         name: 'FOX Soccer Plus',
         tmsId: '66880',
       };


### PR DESCRIPTION
This should fix Fox Soccer Plus and the Bally Linear Channels.

For Bally they removed apple_tv from channel_data.stream_info.  Changing to connected_tv keeps the resolution at 1080.

For Fox Soccer Plus:
The response from the API call from line 532 of fox-handler.ts: `https://api.fox.com/fs/product/curated/v1/sporting/keystone/detail/by_filters?callsign=BTN%2CBTN-DIGITAL%2CFOX%2CFOX-DIGITAL%2CFOXDEP%2CFOXDEP-DIGITAL%2CFS1%2CFS1-DIGITAL%2CFS2%2CFS2-DIGITAL%2CFSP${local_station_call_sign_parameter}&end_date=${endTime}&page=${page}&size=${max_items_per_page}&start_date=${startTime}&video_type=listing`
showed listings.items.networks = fox-soccer-plus instead of fspl

After testing the changes I confirmed that these edits pulled the channel in correctly.